### PR TITLE
"Compiled successfully" instead of "running at"

### DIFF
--- a/src/VueDevelopmentServerMiddleware.cs
+++ b/src/VueDevelopmentServerMiddleware.cs
@@ -86,7 +86,7 @@ namespace VueCliMiddleware
                     // no compiler warnings. So instead of waiting for that, consider it ready as soon
                     // as it starts listening for requests.
                     await npmScriptRunner.StdOut.WaitForMatch(
-                        new Regex("running at", RegexOptions.None, RegexMatchTimeout));
+                        new Regex("Compiled successfully", RegexOptions.None, RegexMatchTimeout));
                 }
                 catch (EndOfStreamException ex)
                 {


### PR DESCRIPTION
(Due to weird a bug when debugging the ASP.NET Core server, it would never detect the line that contains "running at")