### PR TITLE
Additionally look for the StdOut of "Compiled"

### DIFF
--- a/src/VueDevelopmentServerMiddleware.cs
+++ b/src/VueDevelopmentServerMiddleware.cs
@@ -86,7 +86,7 @@ namespace VueCliMiddleware
                     // no compiler warnings. So instead of waiting for that, consider it ready as soon
                     // as it starts listening for requests.
                     await npmScriptRunner.StdOut.WaitForMatch(
-                        new Regex("running at", RegexOptions.None, RegexMatchTimeout));
+                        new Regex("(running at|Compiled)", RegexOptions.None, RegexMatchTimeout));
                 }
                 catch (EndOfStreamException ex)
                 {


### PR DESCRIPTION
As well as looking for "running at" also look for the text "Compiled" to know when the Vue dev server is listening for requests.

I can confirm this is working with my ASP.NET Core 2.2 project.