### PR TITLE
Enhancement: Cleaning up child node process after ending debug

### DIFF
--- a/src/VueCliMiddleware/Util/ProcessTracker.cs
+++ b/src/VueCliMiddleware/Util/ProcessTracker.cs
@@ -1,0 +1,129 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("VueCliMiddleware.Tests")]
+namespace VueCliMiddleware
+{
+    // Uses Windows Job Objects to ensure external processes are killed if the current process is terminated non-gracefully.
+    internal static class ProcessTracker
+    {
+        private static readonly IntPtr _jobHandle;
+
+        static ProcessTracker()
+        {
+            // Requires Win8 or later
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || Environment.OSVersion.Version < new Version(6, 2))
+            {
+                return;
+            }
+
+            // Job name is optional but helps with diagnostics.  Job name must be unique if non-null.
+            _jobHandle = CreateJobObject(IntPtr.Zero, name: $"ProcessTracker{Process.GetCurrentProcess().Id}");
+
+            var extendedInfo = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+            {
+                BasicLimitInformation = new JOBOBJECT_BASIC_LIMIT_INFORMATION
+                {
+                    LimitFlags = JOBOBJECTLIMIT.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+                }
+            };
+
+            var length = Marshal.SizeOf(typeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
+            var extendedInfoPtr = Marshal.AllocHGlobal(length);
+            try
+            {
+                Marshal.StructureToPtr(extendedInfo, extendedInfoPtr, false);
+
+                if (!SetInformationJobObject(_jobHandle, JobObjectInfoType.ExtendedLimitInformation,
+                    extendedInfoPtr, (uint)length))
+                {
+                    throw new Win32Exception();
+                }
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(extendedInfoPtr);
+            }
+        }
+
+        public static void Add(Process process)
+        {
+            if (_jobHandle != IntPtr.Zero)
+            {
+                var success = AssignProcessToJobObject(_jobHandle, process.Handle);
+                if (!success && !process.HasExited)
+                {
+                    throw new Win32Exception();
+                }
+            }
+        }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        static extern IntPtr CreateJobObject(IntPtr lpJobAttributes, string name);
+
+        [DllImport("kernel32.dll")]
+        static extern bool SetInformationJobObject(IntPtr job, JobObjectInfoType infoType,
+            IntPtr lpJobObjectInfo, uint cbJobObjectInfoLength);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
+
+        private enum JobObjectInfoType
+        {
+            AssociateCompletionPortInformation = 7,
+            BasicLimitInformation = 2,
+            BasicUIRestrictions = 4,
+            EndOfJobTimeInformation = 6,
+            ExtendedLimitInformation = 9,
+            SecurityLimitInformation = 5,
+            GroupInformation = 11
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+        {
+            public Int64 PerProcessUserTimeLimit;
+            public Int64 PerJobUserTimeLimit;
+            public JOBOBJECTLIMIT LimitFlags;
+            public UIntPtr MinimumWorkingSetSize;
+            public UIntPtr MaximumWorkingSetSize;
+            public UInt32 ActiveProcessLimit;
+            public Int64 Affinity;
+            public UInt32 PriorityClass;
+            public UInt32 SchedulingClass;
+        }
+
+        [Flags]
+        private enum JOBOBJECTLIMIT : uint
+        {
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct IO_COUNTERS
+        {
+            public UInt64 ReadOperationCount;
+            public UInt64 WriteOperationCount;
+            public UInt64 OtherOperationCount;
+            public UInt64 ReadTransferCount;
+            public UInt64 WriteTransferCount;
+            public UInt64 OtherTransferCount;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+        {
+            public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+            public IO_COUNTERS IoInfo;
+            public UIntPtr ProcessMemoryLimit;
+            public UIntPtr JobMemoryLimit;
+            public UIntPtr PeakProcessMemoryUsed;
+            public UIntPtr PeakJobMemoryUsed;
+        }
+    }
+}

--- a/src/VueCliMiddleware/Util/ScriptRunner.cs
+++ b/src/VueCliMiddleware/Util/ScriptRunner.cs
@@ -74,6 +74,9 @@ namespace VueCliMiddleware
             var process = LaunchNodeProcess(processStartInfo);
             StdOut = new EventedStreamReader(process.StandardOutput);
             StdErr = new EventedStreamReader(process.StandardError);
+
+            // Ensure node process is killed if test process termination is non-graceful.
+            ProcessTracker.Add(process);
         }
 
         public void AttachToLogger(ILogger logger)


### PR DESCRIPTION
- Dangling node process continues to run webpack-dev-server indefinitely
- Using existing AspNetCore libraries to end child process when debug is ended

Sourced from IIS Express Testing:
[https://github.com/aspnet/AspNetCore/blob/3477daf3c4f530dff80f197e0642cb39a26fb07b/src/Servers/IIS/IntegrationTesting.IIS/src/ProcessTracker.cs](url)