### PR TITLE
Optional Task Kill Parameter

### DIFF
--- a/src/VueCliMiddleware/VueDevelopmentServerMiddleware.cs
+++ b/src/VueCliMiddleware/VueDevelopmentServerMiddleware.cs
@@ -18,7 +18,7 @@ namespace VueCliMiddleware
 
         public static void Attach(
             ISpaBuilder spaBuilder,
-            string scriptName, int port = 8080, ScriptRunnerType runner = ScriptRunnerType.Npm, string regex = DefaultRegex)
+            string scriptName, int port = 8080, ScriptRunnerType runner = ScriptRunnerType.Npm, string regex = DefaultRegex, bool forceKill = false)
         {
             var sourcePath = spaBuilder.Options.SourcePath;
             if (string.IsNullOrEmpty(sourcePath))
@@ -34,7 +34,7 @@ namespace VueCliMiddleware
             // Start vue-cli and attach to middleware pipeline
             var appBuilder = spaBuilder.ApplicationBuilder;
             var logger = LoggerFinder.GetOrCreateLogger(appBuilder, LogCategoryName);
-            var portTask = StartVueCliServerAsync(sourcePath, scriptName, logger, port, runner, regex);
+            var portTask = StartVueCliServerAsync(sourcePath, scriptName, logger, port, runner, regex, forceKill);
 
             // Everything we proxy is hardcoded to target http://localhost because:
             // - the requests are always from the local machine (we're not accepting remote
@@ -57,7 +57,7 @@ namespace VueCliMiddleware
         }
 
         private static async Task<int> StartVueCliServerAsync(
-            string sourcePath, string npmScriptName, ILogger logger, int portNumber, ScriptRunnerType runner, string regex)
+            string sourcePath, string npmScriptName, ILogger logger, int portNumber, ScriptRunnerType runner, string regex, bool forceKill = false)
         {
             if (portNumber < 80)
             {
@@ -67,7 +67,7 @@ namespace VueCliMiddleware
             {
                 // if the port we want to use is occupied, terminate the process utilizing that port.
                 // this occurs when "stop" is used from the debugger and the middleware does not have the opportunity to kill the process
-                PidUtils.KillPort((ushort)portNumber);
+                PidUtils.KillPort((ushort)portNumber, forceKill);
             }
             logger.LogInformation($"Starting server on port {portNumber}...");
 

--- a/src/VueCliMiddleware/VueDevelopmentServerMiddlewareExtensions.cs
+++ b/src/VueCliMiddleware/VueDevelopmentServerMiddlewareExtensions.cs
@@ -29,7 +29,8 @@ namespace VueCliMiddleware
             string npmScript = "serve",
             int port = 8080,
             ScriptRunnerType runner = ScriptRunnerType.Npm,
-            string regex = VueCliMiddleware.DefaultRegex)
+            string regex = VueCliMiddleware.DefaultRegex,
+            bool forceKill = false)
         {
             if (spaBuilder == null)
             {
@@ -43,7 +44,7 @@ namespace VueCliMiddleware
                 throw new InvalidOperationException($"To use {nameof(UseVueCli)}, you must supply a non-empty value for the {nameof(SpaOptions.SourcePath)} property of {nameof(SpaOptions)} when calling {nameof(SpaApplicationBuilderExtensions.UseSpa)}.");
             }
 
-            VueCliMiddleware.Attach(spaBuilder, npmScript, port, runner: runner, regex: regex);
+            VueCliMiddleware.Attach(spaBuilder, npmScript, port, runner: runner, regex: regex, forceKill: forceKill);
         }
 
 
@@ -54,10 +55,11 @@ namespace VueCliMiddleware
             string npmScript = "serve",
             int port = 8080,
             ScriptRunnerType runner = ScriptRunnerType.Npm,
-            string regex = VueCliMiddleware.DefaultRegex)
+            string regex = VueCliMiddleware.DefaultRegex,
+            bool forceKill = false)
         {
             if (pattern == null) { throw new ArgumentNullException(nameof(pattern)); }
-            return endpoints.MapFallback(pattern, CreateProxyRequestDelegate(endpoints, options, npmScript, port, runner, regex));
+            return endpoints.MapFallback(pattern, CreateProxyRequestDelegate(endpoints, options, npmScript, port, runner, regex, forceKill));
         }
 
         public static IEndpointConventionBuilder MapToVueCliProxy(
@@ -67,11 +69,12 @@ namespace VueCliMiddleware
             string npmScript = "serve",
             int port = 8080,
             ScriptRunnerType runner = ScriptRunnerType.Npm,
-            string regex = VueCliMiddleware.DefaultRegex)
+            string regex = VueCliMiddleware.DefaultRegex,
+            bool forceKill = false)
         {
             if (pattern == null) { throw new ArgumentNullException(nameof(pattern)); }
             if (sourcePath == null) { throw new ArgumentNullException(nameof(sourcePath)); }
-            return endpoints.MapFallback(pattern, CreateProxyRequestDelegate(endpoints, new SpaOptions { SourcePath = sourcePath }, npmScript, port, runner, regex));
+            return endpoints.MapFallback(pattern, CreateProxyRequestDelegate(endpoints, new SpaOptions { SourcePath = sourcePath }, npmScript, port, runner, regex, forceKill));
         }
 
         public static IEndpointConventionBuilder MapToVueCliProxy(
@@ -80,9 +83,10 @@ namespace VueCliMiddleware
             string npmScript = "serve",
             int port = 8080,
             ScriptRunnerType runner = ScriptRunnerType.Npm,
-            string regex = VueCliMiddleware.DefaultRegex)
+            string regex = VueCliMiddleware.DefaultRegex,
+            bool forceKill = false)
         {
-            return endpoints.MapFallback("{*path}", CreateProxyRequestDelegate(endpoints, options, npmScript, port, runner, regex));
+            return endpoints.MapFallback("{*path}", CreateProxyRequestDelegate(endpoints, options, npmScript, port, runner, regex, forceKill));
         }
 
         public static IEndpointConventionBuilder MapToVueCliProxy(
@@ -91,10 +95,11 @@ namespace VueCliMiddleware
             string npmScript = "serve",
             int port = 8080,
             ScriptRunnerType runner = ScriptRunnerType.Npm,
-            string regex = VueCliMiddleware.DefaultRegex)
+            string regex = VueCliMiddleware.DefaultRegex,
+            bool forceKill = false)
         {
             if (sourcePath == null) { throw new ArgumentNullException(nameof(sourcePath)); }
-            return endpoints.MapFallback("{*path}", CreateProxyRequestDelegate(endpoints, new SpaOptions { SourcePath = sourcePath }, npmScript, port, runner, regex));
+            return endpoints.MapFallback("{*path}", CreateProxyRequestDelegate(endpoints, new SpaOptions { SourcePath = sourcePath }, npmScript, port, runner, regex, forceKill));
         }
 
 
@@ -105,7 +110,8 @@ namespace VueCliMiddleware
             string npmScript = "serve",
             int port = 8080,
             ScriptRunnerType runner = ScriptRunnerType.Npm,
-            string regex = VueCliMiddleware.DefaultRegex)
+            string regex = VueCliMiddleware.DefaultRegex,
+            bool forceKill = false)
         {
             // based on CreateRequestDelegate() https://github.com/aspnet/AspNetCore/blob/master/src/Middleware/StaticFiles/src/StaticFilesEndpointRouteBuilderExtensions.cs#L194
 
@@ -133,7 +139,7 @@ namespace VueCliMiddleware
 
                 if (!string.IsNullOrWhiteSpace(npmScript))
                 {
-                    opt.UseVueCli(npmScript, port, runner, regex);
+                    opt.UseVueCli(npmScript, port, runner, regex, forceKill);
                 }
             });
 


### PR DESCRIPTION
I'm not sure if it is some kind of corporate setting, but on multiple PCs in my work environment the node processes that get left over when the debugger is stopped require the force switch to kill. This adds in an optional parameter to expose an option you had already implemented in the KillPort method.