### PR TITLE
Return empty list from RunProcessReturnOutputSplit if RunProcessRetur…

### DIFF
--- a/src/VueCliMiddleware/Util/KillPort.cs
+++ b/src/VueCliMiddleware/Util/KillPort.cs
@@ -80,7 +80,7 @@ namespace VueCliMiddleware
         private static List<string[]> RunProcessReturnOutputSplit(string fileName, string arguments)
         {
             string result = RunProcessReturnOutput(fileName, arguments);
-            if (result == null) return null;
+            if (result == null) return new List<string[]>();
 
             string[] lines = result.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
             var lineWords = new List<string[]>();


### PR DESCRIPTION
…nOutput returns null

If running a process in `RunProcessReturnOutput()` doesn't succeed or throws an exception, null is returned rather than the process output. `RunProcessReturnOutputSplit()` subsequently used to return null if it received a null value. However, the consuming method, `GetPortPid()`, never did any null checks on the results before trying to use the results in a couple different ways that cause a `NullReferenceException`. By returning an empty list instead of null from `RunProcessReturnOutputSplit()`, `GetPortPid()` can complete without exception and will simply return the default return value of -1 instead.