### PR TITLE
Fix killing previous process on Linux and OSX

### DIFF
--- a/src/VueCliMiddleware/Util/KillPort.cs
+++ b/src/VueCliMiddleware/Util/KillPort.cs
@@ -175,12 +175,14 @@ namespace VueCliMiddleware
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
                     if (force) { args.Add("-9"); }
-                    RunProcessReturnOutput("kill", "");
+                    args.Add(pid.ToString());
+                    RunProcessReturnOutput("kill", string.Join(" ", args));
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
                     if (force) { args.Add("-9"); }
-                    RunProcessReturnOutput("kill", "");
+                    args.Add(pid.ToString());
+                    RunProcessReturnOutput("kill", string.Join(" ", args));
                 }
                 else
                 {


### PR DESCRIPTION
Currently on Linux and OS X kill command was called without any arguments.

Fixes #33 on Linux and OS X.