### PR TITLE
WSL Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 
 #Ignore thumbnails created by Windows
 Thumbs.db
+#Ignore .idea
+*.idea
 #Ignore files built by Visual Studio
 *.obj
 *.exe

--- a/src/VueCliMiddleware/Util/Internals.cs
+++ b/src/VueCliMiddleware/Util/Internals.cs
@@ -166,7 +166,7 @@ namespace VueCliMiddleware
                 // get all the newlines
                 while ((lineBreakPos = Array.IndexOf(buf, '\n', startPos, chunkLength - startPos)) >= 0 && startPos < chunkLength)
                 {
-                    var length = (lineBreakPos + 1) - startPos;
+                    var length = lineBreakPos - startPos;
                     _linesBuffer.Append(buf, startPos, length);
                     OnCompleteLine(_linesBuffer.ToString());
                     _linesBuffer.Clear();

--- a/src/VueCliMiddleware/VueDevelopmentServerMiddleware.cs
+++ b/src/VueCliMiddleware/VueDevelopmentServerMiddleware.cs
@@ -18,7 +18,13 @@ namespace VueCliMiddleware
 
         public static void Attach(
             ISpaBuilder spaBuilder,
-            string scriptName, int port = 8080, bool https = false, ScriptRunnerType runner = ScriptRunnerType.Npm, string regex = DefaultRegex, bool forceKill = false)
+            string scriptName,
+            int port = 8080,
+            bool https = false,
+            ScriptRunnerType runner = ScriptRunnerType.Npm,
+            string regex = DefaultRegex,
+            bool forceKill = false,
+            bool wsl = false)
         {
             var sourcePath = spaBuilder.Options.SourcePath;
             if (string.IsNullOrEmpty(sourcePath))
@@ -34,7 +40,7 @@ namespace VueCliMiddleware
             // Start vue-cli and attach to middleware pipeline
             var appBuilder = spaBuilder.ApplicationBuilder;
             var logger = LoggerFinder.GetOrCreateLogger(appBuilder, LogCategoryName);
-            var portTask = StartVueCliServerAsync(sourcePath, scriptName, logger, port, runner, regex, forceKill);
+            var portTask = StartVueCliServerAsync(sourcePath, scriptName, logger, port, runner, regex, forceKill, wsl);
 
             // Everything we proxy is hardcoded to target http://localhost because:
             // - the requests are always from the local machine (we're not accepting remote
@@ -55,7 +61,14 @@ namespace VueCliMiddleware
         }
 
         private static async Task<int> StartVueCliServerAsync(
-            string sourcePath, string npmScriptName, ILogger logger, int portNumber, ScriptRunnerType runner, string regex, bool forceKill = false)
+            string sourcePath,
+            string npmScriptName,
+            ILogger logger,
+            int portNumber,
+            ScriptRunnerType runner,
+            string regex,
+            bool forceKill = false,
+            bool wsl = false)
         {
             if (portNumber < 80)
             {
@@ -76,7 +89,7 @@ namespace VueCliMiddleware
                 { "BROWSER", "none" }, // We don't want vue-cli to open its own extra browser window pointing to the internal dev server port
             };
 
-            var npmScriptRunner = new ScriptRunner(sourcePath, npmScriptName, $"--port {portNumber:0}", envVars, runner: runner);
+            var npmScriptRunner = new ScriptRunner(sourcePath, npmScriptName, $"--port {portNumber:0}", envVars, runner: runner, wsl: wsl);
             AppDomain.CurrentDomain.DomainUnload += (s, e) => npmScriptRunner?.Kill();
             AppDomain.CurrentDomain.ProcessExit += (s, e) => npmScriptRunner?.Kill();
             AppDomain.CurrentDomain.UnhandledException += (s, e) => npmScriptRunner?.Kill();

--- a/src/VueCliMiddleware/VueDevelopmentServerMiddlewareExtensions.cs
+++ b/src/VueCliMiddleware/VueDevelopmentServerMiddlewareExtensions.cs
@@ -25,6 +25,8 @@ namespace VueCliMiddleware
         /// <param name="https">Specify vue cli server schema </param>
         /// <param name="runner">Specify the runner, Npm and Yarn are valid options. Yarn support is HIGHLY experimental.</param>
         /// <param name="regex">Specify a custom regex string to search for in the log indicating proxied server is running. VueCli: "running at", QuasarCli: "Compiled successfully"</param>
+        /// <param name="forceKill"></param>
+        /// <param name="wsl"></param>
         public static void UseVueCli(
             this ISpaBuilder spaBuilder,
             string npmScript = "serve",
@@ -32,7 +34,8 @@ namespace VueCliMiddleware
             bool https = false,
             ScriptRunnerType runner = ScriptRunnerType.Npm,
             string regex = VueCliMiddleware.DefaultRegex,
-            bool forceKill = false)
+            bool forceKill = false,
+            bool wsl = false)
         {
             if (spaBuilder == null)
             {
@@ -46,7 +49,7 @@ namespace VueCliMiddleware
                 throw new InvalidOperationException($"To use {nameof(UseVueCli)}, you must supply a non-empty value for the {nameof(SpaOptions.SourcePath)} property of {nameof(SpaOptions)} when calling {nameof(SpaApplicationBuilderExtensions.UseSpa)}.");
             }
 
-            VueCliMiddleware.Attach(spaBuilder, npmScript, port, https: https, runner: runner, regex: regex, forceKill: forceKill);
+            VueCliMiddleware.Attach(spaBuilder, npmScript, port, https: https, runner: runner, regex: regex, forceKill: forceKill, wsl: wsl);
         }
 
 
@@ -59,10 +62,11 @@ namespace VueCliMiddleware
             bool https = false,
             ScriptRunnerType runner = ScriptRunnerType.Npm,
             string regex = VueCliMiddleware.DefaultRegex,
-            bool forceKill = false)
+            bool forceKill = false,
+            bool wsl = false)
         {
             if (pattern == null) { throw new ArgumentNullException(nameof(pattern)); }
-            return endpoints.MapFallback(pattern, CreateProxyRequestDelegate(endpoints, options, npmScript, port, https, runner, regex, forceKill));
+            return endpoints.MapFallback(pattern, CreateProxyRequestDelegate(endpoints, options, npmScript, port, https, runner, regex, forceKill, wsl));
         }
 
         public static IEndpointConventionBuilder MapToVueCliProxy(
@@ -74,11 +78,12 @@ namespace VueCliMiddleware
             bool https = false,
             ScriptRunnerType runner = ScriptRunnerType.Npm,
             string regex = VueCliMiddleware.DefaultRegex,
-            bool forceKill = false)
+            bool forceKill = false,
+            bool wsl = false)
         {
             if (pattern == null) { throw new ArgumentNullException(nameof(pattern)); }
             if (sourcePath == null) { throw new ArgumentNullException(nameof(sourcePath)); }
-            return endpoints.MapFallback(pattern, CreateProxyRequestDelegate(endpoints, new SpaOptions { SourcePath = sourcePath }, npmScript, port, https, runner, regex, forceKill));
+            return endpoints.MapFallback(pattern, CreateProxyRequestDelegate(endpoints, new SpaOptions { SourcePath = sourcePath }, npmScript, port, https, runner, regex, forceKill, wsl));
         }
 
         public static IEndpointConventionBuilder MapToVueCliProxy(
@@ -89,9 +94,10 @@ namespace VueCliMiddleware
             bool https = false,
             ScriptRunnerType runner = ScriptRunnerType.Npm,
             string regex = VueCliMiddleware.DefaultRegex,
-            bool forceKill = false)
+            bool forceKill = false,
+            bool wsl = false)
         {
-            return endpoints.MapFallback("{*path}", CreateProxyRequestDelegate(endpoints, options, npmScript, port, https, runner, regex, forceKill));
+            return endpoints.MapFallback("{*path}", CreateProxyRequestDelegate(endpoints, options, npmScript, port, https, runner, regex, forceKill, wsl));
         }
 
         public static IEndpointConventionBuilder MapToVueCliProxy(
@@ -102,10 +108,11 @@ namespace VueCliMiddleware
             bool https = false,
             ScriptRunnerType runner = ScriptRunnerType.Npm,
             string regex = VueCliMiddleware.DefaultRegex,
-            bool forceKill = false)
+            bool forceKill = false,
+            bool wsl = false)
         {
             if (sourcePath == null) { throw new ArgumentNullException(nameof(sourcePath)); }
-            return endpoints.MapFallback("{*path}", CreateProxyRequestDelegate(endpoints, new SpaOptions { SourcePath = sourcePath }, npmScript, port, https, runner, regex, forceKill));
+            return endpoints.MapFallback("{*path}", CreateProxyRequestDelegate(endpoints, new SpaOptions { SourcePath = sourcePath }, npmScript, port, https, runner, regex, forceKill, wsl));
         }
 
 
@@ -118,7 +125,8 @@ namespace VueCliMiddleware
             bool https = false,
             ScriptRunnerType runner = ScriptRunnerType.Npm,
             string regex = VueCliMiddleware.DefaultRegex,
-            bool forceKill = false)
+            bool forceKill = false,
+            bool wsl = false)
         {
             // based on CreateRequestDelegate() https://github.com/aspnet/AspNetCore/blob/master/src/Middleware/StaticFiles/src/StaticFilesEndpointRouteBuilderExtensions.cs#L194
 
@@ -146,7 +154,7 @@ namespace VueCliMiddleware
 
                 if (!string.IsNullOrWhiteSpace(npmScript))
                 {
-                    opt.UseVueCli(npmScript, port, https, runner, regex, forceKill);
+                    opt.UseVueCli(npmScript, port, https, runner, regex, forceKill, wsl);
                 }
             });
 


### PR DESCRIPTION
- add wsl flag
- when wsl flag is true, run via wsl
- Use WriteLine and remove preceding `<s>` in console output
- `Internals.cs` exclude the '\n' character
- ignore .idea folder

The output was messed up in WSL so that's the main reason for the changes to the dev logging, I've tested on Windows wsl/cmd both display fine.