### PR TITLE
Fix slow response time of requests

### DIFF
--- a/src/VueCliMiddleware/VueDevelopmentServerMiddleware.cs
+++ b/src/VueCliMiddleware/VueDevelopmentServerMiddleware.cs
@@ -36,11 +36,11 @@ namespace VueCliMiddleware
             var logger = LoggerFinder.GetOrCreateLogger(appBuilder, LogCategoryName);
             var portTask = StartVueCliServerAsync(sourcePath, scriptName, logger, port, runner, regex, forceKill);
 
-            // Everything we proxy is hardcoded to target http://localhost because:
+            // Everything we proxy is hardcoded to target localhost because:
             // - the requests are always from the local machine (we're not accepting remote
             //   requests that go directly to the vue-cli server)
             var targetUriTask = portTask.ContinueWith(
-                task => new UriBuilder(https ? "https" : "http", "localhost", task.Result).Uri);
+                task => new UriBuilder(https ? "https" : "http", "127.0.0.1", task.Result).Uri);
 
             SpaProxyingExtensions.UseProxyToSpaDevelopmentServer(spaBuilder, () =>
             {


### PR DESCRIPTION
I've noticed that the response times of requests going through this middleware are slow (2s-4s in my case).
After a bit of investigation, i found [this discussion](https://github.com/dotnet/aspnetcore/issues/18062) about `UseProxyToSpaDevelopmentServer` which is used internally in this library.
It turns out that webpack/nodejs server is listening to IPv4 only. However, SpaProxy on localhost tries IPv6 first so it takes few seconds before trying IPv4.
The solution is to target 127.0.0.1 directly.

This is some timing analysis:
With localhost:
![Annotation 2020-08-28 191151](https://user-images.githubusercontent.com/37005069/91604503-ab69e000-e966-11ea-81c4-a26ab8a796e2.png)

With 127.0.0.1:
![Annotation 2020-08-28 191449](https://user-images.githubusercontent.com/37005069/91604542-be7cb000-e966-11ea-9fdd-85bbf543a04b.png)
